### PR TITLE
 Add Google Calendar integration using access token and Events API

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@react-oauth/google": "^0.12.2",
         "@supabase/supabase-js": "^2.50.2",
         "clsx": "^2.1.1",
         "lucide-react": "^0.525.0",
@@ -1116,6 +1117,16 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.2",
     "@supabase/supabase-js": "^2.50.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",

--- a/frontend/src/components/Events.jsx
+++ b/frontend/src/components/Events.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { supabase } from "../supabaseClient";
+import { useGoogleLogin } from "@react-oauth/google";
+import { addEventToGoogleCalendar } from "../lib/googleCalendarUtils";
 
 export default function Events() {
 	const [events, setEvents] = useState([]);
@@ -7,6 +9,20 @@ export default function Events() {
 	const [userId, setUserId] = useState(null);
 	const [points, setPoints] = useState(0);
 	const [loading, setLoading] = useState(true);
+
+	const [googleToken, setGoogleToken] = useState(null);
+
+	const loginWithGoogleCalendar = useGoogleLogin({
+		scope: "https://www.googleapis.com/auth/calendar.events",
+		onSuccess: (tokenResponse) => {
+			setGoogleToken(tokenResponse.access_token);
+			alert("Google Calendar Connected!");
+		},
+		onError: (err) => {
+			console.error("Google login failed:", err);
+			alert("Failed to connect to Google Calendar");
+		},
+	});
 
 	useEffect(() => {
 		(async () => {
@@ -87,7 +103,18 @@ export default function Events() {
 										<button onClick={() => toggleRegister(e.id)} className={`text-sm font-medium py-2 px-4 rounded transition ${isReg ? "bg-green-500 hover:bg-green-600" : "bg-blue-500 hover:bg-blue-600"} text-white`}>
 											{isReg ? "Registered" : "Register"}
 										</button>
-										<button className="bg-gray-200 hover:bg-gray-300 text-gray-800 text-sm font-medium py-2 px-4 rounded transition">Add to Outlook Calendar</button>
+										<button
+											onClick={() => {
+												if (googleToken) {
+													addEventToGoogleCalendar(googleToken, e);
+												} else {
+													loginWithGoogleCalendar();
+												}
+											}}
+											className="bg-red-500 hover:bg-red-600 text-white text-sm font-medium py-2 px-4 rounded transition"
+										>
+											{googleToken ? "Add to Google Calendar" : "Connect Google Calendar"}
+										</button>
 									</div>
 								</div>
 							);

--- a/frontend/src/lib/googleCalendarUtils.js
+++ b/frontend/src/lib/googleCalendarUtils.js
@@ -1,0 +1,36 @@
+export async function addEventToGoogleCalendar(accessToken, event) {
+	try {
+		const response = await fetch("https://www.googleapis.com/calendar/v3/calendars/primary/events", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				summary: event.title,
+				location: event.location,
+				description: event.description,
+				start: {
+					dateTime: new Date(event.date).toISOString(),
+					timeZone: "America/New_York", 
+				},
+				end: {
+					dateTime: new Date(new Date(event.date).getTime() + 60 * 60 * 1000).toISOString(), 
+					timeZone: "America/New_York",
+				},
+			}),
+		});
+
+		const data = await response.json();
+
+		if (!response.ok) {
+			console.error("Google Calendar Error:", data);
+			alert("Failed to add event to Google Calendar.");
+		} else {
+			alert("Event added to Google Calendar!");
+		}
+	} catch (err) {
+		console.error("Error adding event:", err);
+		alert("Something went wrong while adding the event.");
+	}
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,11 +4,16 @@ import "./index.css";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./router.jsx";
 import { AuthContextProvider } from "./context/AuthContext.jsx";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
 
 createRoot(document.getElementById("root")).render(
 	<StrictMode>
-		<AuthContextProvider>
-			<RouterProvider router={router} />
-		</AuthContextProvider>
+		<GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+			<AuthContextProvider>
+				<RouterProvider router={router} />
+			</AuthContextProvider>
+		</GoogleOAuthProvider>
 	</StrictMode>
 );


### PR DESCRIPTION
## Description

- **What does this PR do?**  
  Implements Google Calendar integration using OAuth access token and the Google Calendar Events API to allow users to add events directly to their Google Calendars.

- **Why is it necessary or valuable?**  
  This allows users to seamlessly save MICS events to their personal Google Calendars, enhancing convenience, organization, and event participation.

- **What is intentionally left out and will be done in a later PR?**  
  Potential Outlook Calendar integration.

---

## Milestones / Related Work

- **Feature or user story this contributes to:**  
  [Add Events to my Google Calendar](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.c1hbr5v3ca4m)  
  _As a user, I want to add MICS events to my Google Calendar so I can stay organized and never miss an event._

- **Milestone or version target:**  
  [2.5 Users can add events to their Google Calendar](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.yseb0cl2joye)

---

## Resources and References

- **Documentation & Libraries Used:**  
  - [Google Calendar Events API](https://developers.google.com/calendar/api/v3/reference/events/insert)  
  - [@react-oauth/google (NPM)](https://www.npmjs.com/package/@react-oauth/google)

---

## Test Plan

- **How was this tested?**  
  Logged in with Google, authorized calendar access, manually added multiple events, and confirmed appearance in Google Calendar.

- **Screenshots or recordings:**  
  ![image](https://github.com/user-attachments/assets/f838ff31-9f64-4ec2-855e-a8c167626ad9)

- **Seed or mock data used:**  
  Pulled from live Supabase `events` table

- **Loom demo:**  
  [Click to watch](https://www.loom.com/share/d1ae4d9318b649b884f190da3badeb94?sid=3b01602d-29a6-4122-b9d7-0f94eb56deb9)

---

