### PR TITLE
add like/unlike interactions | personalized PageRank matching tbd (TC #1)

### DIFF
--- a/frontend/src/components/Events.jsx
+++ b/frontend/src/components/Events.jsx
@@ -12,7 +12,7 @@ export default function Events({ role }) {
 	const [points, setPoints] = useState(0);
 	const [loading, setLoading] = useState(true);
 	const [showModal, setShowModal] = useState(false);
-	const [submitting, setsSubmitting] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
 
 	const [googleToken, setGoogleToken] = useState(null);
 
@@ -103,13 +103,13 @@ export default function Events({ role }) {
 							<AddEventModal
 								onClose={() => setShowModal(false)}
 								onSubmit={async (newEvent) => {
-									setsSubmitting(true);
+									setSubmitting(true);
 									const { data, error } = await supabase
 										.from("events")
 										.insert([{ ...newEvent, created_by: userId }])
 										.select()
 										.single();
-									setsSubmitting(false);
+									setSubmitting(false);
 									if (!error && data) {
 										setEvents((prev) => [...prev, data]);
 										setShowModal(false);

--- a/frontend/src/components/MentorPage.jsx
+++ b/frontend/src/components/MentorPage.jsx
@@ -8,44 +8,98 @@ import { PRESET_SKILLS, PRESET_INTERESTS } from "./constants/presets";
 
 export default function MentorPage() {
 	const { session } = UserAuth();
+	const userId = session?.user?.id;
+
 	const [userProfile, setUserProfile] = useState(null);
+	const [mentors, setMentors] = useState([]);
+	const [likesMap, setLikesMap] = useState({});
+	const [likedMentors, setLikedMentors] = useState(new Set());
 	const [topMentors, setTopMentors] = useState([]);
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
-		if (!session?.user?.id) return;
-		const fetchProfile = async () => {
-			const { data, error } = await supabase.from("users").select("id, name, year, bio, skills, interests, ai_interest, experience_years, preferred_meeting, points, profile_picture").eq("id", session.user.id).single();
-			if (error) {
-				console.error("Error loading user profile:", error);
-			} else {
-				setUserProfile(data);
-			}
-		};
-		fetchProfile();
-	}, [session]);
+		if (!userId) return;
+		(async () => {
+			const { data, error } = await supabase.from("users").select("id, name, year, bio, skills, interests, ai_interest, experience_years, preferred_meeting, points, profile_picture").eq("id", userId).single();
+			if (error) console.error("Error loading user profile:", error);
+			else setUserProfile(data);
+		})();
+	}, [userId]);
 
 	useEffect(() => {
 		if (!userProfile) return;
-		const fetchMentors = async () => {
-			const { data, error } = await supabase.from("users").select("*").ilike("mentor_role", "mentor").neq("id", session.user.id);
+		(async () => {
+			const { data, error } = await supabase.from("users").select("*").ilike("mentor_role", "mentor").neq("id", userId);
+			if (error) console.error("Error fetching mentors:", error);
+			else setMentors(data);
+		})();
+	}, [userProfile, userId]);
 
+	useEffect(() => {
+		if (!userId || mentors.length === 0) return;
+		(async () => {
+			const mentorIds = mentors.map((m) => m.id);
+			const { data: rows, error } = await supabase.from("interactions").select("to_user, weight").eq("type", "like").eq("from_user", userId).in("to_user", mentorIds);
 			if (error) {
-				console.error("Error fetching mentors:", error);
+				console.error("Error fetching likes:", error);
+				setLikesMap({});
 			} else {
-				const matches = getTopMentorMatches(userProfile, data, PRESET_SKILLS, PRESET_INTERESTS, data.length < 6 ? data.length : 6);
-				setTopMentors(matches);
+				const map = {};
+				rows.forEach(({ to_user, weight }) => {
+					map[to_user] = (map[to_user] || 0) + weight;
+				});
+				setLikesMap(map);
+				setLikedMentors(new Set(Object.keys(map)));
 			}
-			setLoading(false);
-		};
-		fetchMentors();
-	}, [userProfile, session]);
+		})();
+	}, [userId, mentors]);
+
+	useEffect(() => {
+		if (!userProfile || mentors.length === 0) return;
+		const topN = Math.min(mentors.length, 6);
+		const matches = getTopMentorMatches(userProfile, mentors, PRESET_SKILLS, PRESET_INTERESTS, likesMap, topN);
+		setTopMentors(matches);
+		setLoading(false);
+	}, [userProfile, mentors, likesMap]);
+
+	const toggleLike = async (mentorId) => {
+		if (!userId) return;
+		const isLiked = likedMentors.has(mentorId);
+
+		if (isLiked) {
+			const { error } = await supabase.from("interactions").delete().eq("from_user", userId).eq("to_user", mentorId).eq("type", "like");
+			if (error) console.error("Error unliking:", error);
+			else {
+				setLikedMentors((prev) => {
+					const next = new Set(prev);
+					next.delete(mentorId);
+					return next;
+				});
+				setLikesMap((prev) => {
+					const next = { ...prev };
+					delete next[mentorId];
+					return next;
+				});
+			}
+		} else {
+			const { error } = await supabase.from("interactions").insert({ from_user: userId, to_user: mentorId, type: "like", weight: 1 });
+			if (error) console.error("Error liking:", error);
+			else {
+				setLikedMentors((prev) => new Set(prev).add(mentorId));
+				setLikesMap((prev) => ({
+					...prev,
+					[mentorId]: (prev[mentorId] || 0) + 1,
+				}));
+			}
+		}
+	};
 
 	if (loading) return <LoadingSpinner />;
 
 	return (
 		<div className="bg-gradient-to-b from-blue-100 via-blue-200 to-blue-300 text-gray-900 min-h-screen">
 			<NavigationBar />
+
 			<h1 className="text-3xl font-bold text-center my-6">Mentor Matching</h1>
 			<p className="text-center mb-10 text-gray-600">Browse featured mentors matched by interest & skills</p>
 
@@ -100,7 +154,12 @@ export default function MentorPage() {
 
 						<div className="text-sm text-gray-600 mb-2">{mentor.points ?? 0} total points</div>
 
-						<button className="mt-  2 px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full text-sm shadow-sm">Connect</button>
+						<div className="flex gap-2">
+							<button className="px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full text-sm shadow-sm">Connect</button>
+							<button onClick={() => toggleLike(mentor.id)} className={`px-4 py-2 rounded-full text-sm shadow-sm ${likedMentors.has(mentor.id) ? "bg-red-400 hover:bg-red-500 text-white" : "bg-yellow-400 hover:bg-yellow-500 text-white"}`}>
+								{likedMentors.has(mentor.id) ? "Unlike" : "Like"}
+							</button>
+						</div>
 					</div>
 				))}
 			</div>

--- a/frontend/src/components/constants/presets.js
+++ b/frontend/src/components/constants/presets.js
@@ -1,5 +1,3 @@
-// src/constants/presets.js
-
 export const PRESET_SKILLS = [
 	"Bootstrap",
 	"C#",


### PR DESCRIPTION
# Description  
- **What does this PR do?**  
Adds like/unlike buttons on the `MentorPage`. Likes are saved in Supabase and loaded back in. These likes are used to prep for a future update where we’ll use Personalized PageRank. Current match logic still uses cosine similarity.

- **Why is it necessary or valuable?**  
 This makes it possible to include user feedback in mentor matching. Later on, we’ll use likes to find mentors liked by similar users and improve recommendations. This PR builds the full like/unlike flow to make that possible.

- **What is intentionally left out and will be done in a later PR?**  
  - Adding the actual Personalized PageRank algorithm  
  - Using likes in match scoring  

---

# Milestones / Related Work  
- Feature or user story this contributes to: - 3[.9 Mentor Page like and unlike interactions (TC #1)
](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.82chwiwljuy6)
---

# Resources and References  
- Personalized PageRank YT Vid:https://www.youtube.com/watch?v=RVIr8Y5isek
---

# Test Plan  
- **How was this tested?**  
  - Manually liked and unliked mentors  
  - Checked if likes saved and loaded correctly after refresh  
  - Verified UI changed correctly  

- **Screenshots :**  
  - <img width="1220" height="874" alt="image" src="https://github.com/user-attachments/assets/8dd4cd4e-a796-453b-912a-3a3344d49e15" />

- **Seed or mock data used:**  
  - 1 mentor accounts created manually  

---

# Additional Notes  
- **Personalized PageRank plan:**  
Next couple PR's will use likes to build a graph of users and mentors. Then we’ll run a personalized PageRank to rank mentors based on both profile similarity and shared likes. Cosine similarity will be mixed in to guide weights.
- All data this needs (user profile, mentor list, like map) is already being passed and handled, so we’re ready for that update.
