### PR TITLE
Constants for weight blending (TC #1)

### DIFF
--- a/frontend/src/utils/mentorMatchUtils.js
+++ b/frontend/src/utils/mentorMatchUtils.js
@@ -36,7 +36,7 @@ function encodeAI(user) {
 	return [user.ai_interest ? 1 : 0];
 }
 
-function encodeExperience(user, maxYears = 5) {
+function encodeExperience(user, maxYears = MAX_YEARS) {
 	let years = 0;
 	const raw = user.experience_years;
 	if (raw != null) {
@@ -59,9 +59,7 @@ function vectorizeUser(user, globalSkills, globalInterests) {
 	const aiVec = encodeAI(user).map((v) => v * FEATURE_WEIGHTS.ai_interest);
 	const expVec = encodeExperience(user, MAX_YEARS).map((v) => v * FEATURE_WEIGHTS.experience_years);
 	const meetVec = encodeMeeting(user).map((v) => v * FEATURE_WEIGHTS.preferred_meeting);
-	const fullVec = [...skillVec, ...interestVec, ...aiVec, ...expVec, ...meetVec];
-
-	return fullVec;
+	return [...skillVec, ...interestVec, ...aiVec, ...expVec, ...meetVec];
 }
 
 // Calculates how similar two vectors are using cosine similarity
@@ -73,17 +71,7 @@ function cosineSimilarity(vecA, vecB) {
 	return dotProduct / (magnitudeA * magnitudeB);
 }
 
-// Finds and returns the top mentor matches based on similarity to the current user
-export function getTopMentorMatches(currentUser, mentors, globalSkills, globalInterests, topN = 5) {
-	const currentUserVector = vectorizeUser(currentUser, globalSkills, globalInterests);
-
-	const scoredMentors = mentors.map((mentor) => {
-		const mentorVector = vectorizeUser(mentor, globalSkills, globalInterests);
-		const similarityScore = cosineSimilarity(currentUserVector, mentorVector);
-		return { mentor, score: similarityScore };
-	});
-
-	// Sort by descending score and return top
-	const sorted = scoredMentors.sort((a, b) => b.score - a.score);
-	return sorted.slice(0, topN);
-}
+// weights for blending simil. vs likes
+const ALPHA_SIM = 0.6;
+const BETA_LIKES = 0.4;
+const MAX_LIKES = 5;


### PR DESCRIPTION
# Description  
- What does this PR do?  
Adds weight constants for blending similarity and likes into future mentor matching algorithms, defines `MAX_LIKES`, and introduces a `MAX_YEARS` constant for standardizing experience encoding. Also removes the current `getTopMentorMatches` function for future refactor.

- Why is it necessary or valuable?  
This lays the groundwork for a more complex and tunable mentor matching system that balances similarity with community feedback (likes). It also removes outdated logic to prepare for the next iteration of the matching algorithm.

- What is intentionally left out and will be done in a later PR?  
The new matching logic that uses the weights is not yet implemented, this PR only sets up constants and cleanup. Refactored `getTopMentorMatches` and integration with likes will come in a follow-up.

---

# Milestones / Related Work  
- Milestone or version target: - [3.10 Mentor Matching Logic using Personalized Page Rank (TC #1)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.hb4uoztr4m4p)

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
Applications of PageRank to Recommendation Systems - [Stanford Lec.](https://cs.stanford.edu/people/plofgren/Fast-PPR_KDD_Talk.pdf)
---


# Additional Notes  
- Known limitations: `getTopMentorMatches` is temporarily removed and should not be used in current state.
- Planned follow-up PRs: Refactor matching logic to include blended scoring using `ALPHA_SIM` and `BETA_LIKES`.
