### PR TITLE
Add UI for feature-weight adjustment with slider

### DIFF
--- a/frontend/src/components/MentorPage.jsx
+++ b/frontend/src/components/MentorPage.jsx
@@ -10,6 +10,15 @@ export default function MentorPage() {
 	const { session } = UserAuth();
 	const userId = session?.user?.id;
 
+	const [weights, setWeights] = useState({
+		skills: 0.4,
+		interests: 0.3,
+		ai_interest: 0.1,
+		experience_years: 0.1,
+		preferred_meeting: 0.1,
+	});
+	const [showWeightModal, setShowWeightModal] = useState(false);
+
 	const [userProfile, setUserProfile] = useState(null);
 	const [mentors, setMentors] = useState([]);
 	const [likesMap, setLikesMap] = useState({});
@@ -57,15 +66,14 @@ export default function MentorPage() {
 	useEffect(() => {
 		if (!userProfile || mentors.length === 0) return;
 		const topN = Math.min(mentors.length, 6);
-		const matches = getTopMentorMatches(userProfile, mentors, PRESET_SKILLS, PRESET_INTERESTS, likesMap, topN);
+		const matches = getTopMentorMatches(userProfile, mentors, PRESET_SKILLS, PRESET_INTERESTS, likesMap, topN, weights);
 		setTopMentors(matches);
 		setLoading(false);
-	}, [userProfile, mentors, likesMap]);
+	}, [userProfile, mentors, likesMap, weights]);
 
 	const toggleLike = async (mentorId) => {
 		if (!userId) return;
 		const isLiked = likedMentors.has(mentorId);
-
 		if (isLiked) {
 			const { error } = await supabase.from("interactions").delete().eq("from_user", userId).eq("to_user", mentorId).eq("type", "like");
 			if (error) console.error("Error unliking:", error);
@@ -99,9 +107,32 @@ export default function MentorPage() {
 	return (
 		<div className="bg-gradient-to-b from-blue-100 via-blue-200 to-blue-300 text-gray-900 min-h-screen">
 			<NavigationBar />
+			<div className="flex justify-between items-center mx-10 mt-6">
+				<h1 className="text-3xl font-bold">Mentor Matching</h1>
+				<button onClick={() => setShowWeightModal(true)} className="px-4 py-2 bg-gray-200 rounded">
+					Adjust Weights
+				</button>
+			</div>
 
-			<h1 className="text-3xl font-bold text-center my-6">Mentor Matching</h1>
-			<p className="text-center mb-10 text-gray-600">Browse featured mentors matched by interest & skills</p>
+			{showWeightModal && (
+				<div className="fixed inset-0 z-50 bg-black bg-opacity-50 flex items-center justify-center">
+					<div className="bg-white p-6 rounded-lg w-96 z-50">
+						<h2 className="text-xl mb-4">Feature Weights</h2>
+						{Object.entries(weights).map(([key, val]) => (
+							<div key={key} className="mb-3">
+								<label className="block font-medium">{key.replace("_", " ")}</label>
+								<input type="range" min="0" max="1" step="0.01" value={val} onChange={(e) => setWeights((w) => ({ ...w, [key]: parseFloat(e.target.value) }))} className="w-full" />
+								<div className="text-sm text-right">{(val * 100).toFixed(0)}%</div>
+							</div>
+						))}
+						<div className="flex justify-end gap-2 mt-4">
+							<button onClick={() => setShowWeightModal(false)} className="px-4 py-2 bg-gray-200 rounded">
+								Close
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
 
 			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 m-10">
 				{topMentors.map(({ mentor, score }) => (
@@ -109,18 +140,14 @@ export default function MentorPage() {
 						<div className="w-24 h-24 rounded-full overflow-hidden shadow-md border-4 border-blue-200 mb-4">
 							<img src={mentor.profile_picture || "https://picsum.photos/200"} alt={mentor.name} className="object-cover w-full h-full" />
 						</div>
-
 						<div className="text-lg font-bold flex items-center gap-2">
 							{mentor.name}
 							<span className="text-xs bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded-full">Mentor</span>
 						</div>
-
 						<div className="text-sm text-gray-600 mb-2">
 							{mentor.year || "N/A"} • {mentor.experience_years || 0} yrs experience
 						</div>
-
 						<p className="text-sm text-gray-700 mb-3">{mentor.bio || "No bio available."}</p>
-
 						<div className="w-full mb-3">
 							<div className="font-semibold text-sm mb-1">Skills</div>
 							<div className="flex flex-wrap gap-2 justify-center">
@@ -132,7 +159,6 @@ export default function MentorPage() {
 									))}
 							</div>
 						</div>
-
 						<div className="w-full mb-3">
 							<div className="font-semibold text-sm mb-1">Interests</div>
 							<div className="flex flex-wrap gap-2 justify-center">
@@ -143,17 +169,14 @@ export default function MentorPage() {
 								))}
 							</div>
 						</div>
-
 						<div className="w-full mb-2">
 							<div className="text-sm text-gray-600 font-medium mb-1">Match Score</div>
 							<div className="w-full bg-blue-100 rounded-full h-2 overflow-hidden">
-								<div className="h-full bg-gradient-to-r from-green-400 to-green-600 rounded-full" style={{ width: `${Math.round(score * 100)}%` }}></div>
+								<div className="h-full bg-gradient-to-r from-green-400 to-green-600 rounded-full" style={{ width: `${Math.round(score * 100)}%` }} />
 							</div>
 							<div className="text-sm mt-1 text-blue-700 font-semibold">{Math.round(score * 100)}% match</div>
 						</div>
-
 						<div className="text-sm text-gray-600 mb-2">{mentor.points ?? 0} total points</div>
-
 						<div className="flex gap-2">
 							<button className="px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full text-sm shadow-sm">Connect</button>
 							<button onClick={() => toggleLike(mentor.id)} className={`px-4 py-2 rounded-full text-sm shadow-sm ${likedMentors.has(mentor.id) ? "bg-red-400 hover:bg-red-500 text-white" : "bg-yellow-400 hover:bg-yellow-500 text-white"}`}>


### PR DESCRIPTION
## Description
- **What does this PR do?**  
  Introduces a modal dialog on the MentorPage where users can dynamically adjust the relative weights of matching features (skills, interests, AI interest, experience, meeting preference) via sliders, and wires those updated weights into the matching algorithm (to be added).

- **Why is it necessary or valuable?**  
  Gives end users control to tailor the mentor-matching algorithm to their individual priorities, making matches more personalized and transparent.

- **What is intentionally left out**  
  - Persisting user’s weight preferences
  - More granular input components
  - Dynamic Weight Changing Logic

## Milestones / Related Work
- **Feature or user story this contributes to: [3.11 UI for adjustable weighting for attributes within Mentor Matching Page 9 (TC#1)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.go7nh9qx5kc3)


## Test Plan
- **How was this tested?**  
  - Manually opened the “Adjust Weights” modal, moved each slider.
  - Verified that closing and reopening the modal preserves the last set values.  
- **Screenshots or recordings:**  
<img width="680" height="960" alt="image" src="https://github.com/user-attachments/assets/3134568b-8d29-46d8-8b00-6c9ff03ef462" />

### Edge Cases Tested
- No mentors loaded → modal opens/closes without errors  
- Rapid slider movement 

## Additional Notes
- **Known limitations:** Weights aren’t normalized, users could set conflicting values, Logic
- **Planned follow-up PRs:**  
  1. Persist weight settings per user
  2. Add automatic normalization so sliders always total 100%  
  3. Dynamic weight changing Logic
