### PR TITLE
Create feedback modal and refractor constants in options, recommended events ui & logic tbd (TC #2)

### DIFF
--- a/frontend/src/components/FeedbackModal.jsx
+++ b/frontend/src/components/FeedbackModal.jsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from "react";
+import { ThumbsUp, ThumbsDown, X } from "lucide-react";
+import { POSITIVE_OPTIONS, NEGATIVE_OPTIONS } from "./constants/options";
+
+export default function FeedbackModal({ visible, feedbackType, eventTitle, onSubmit, onClose }) {
+	const [selectedReasons, setSelectedReasons] = useState(new Set());
+
+	useEffect(() => {
+		if (!visible) setSelectedReasons(new Set());
+	}, [visible]);
+
+	if (!visible) return null;
+
+	const options = feedbackType === "like" ? POSITIVE_OPTIONS : NEGATIVE_OPTIONS;
+	const titleText = feedbackType === "like" ? "What did you like about this event?" : "What didn’t you like about this event?";
+	const Icon = feedbackType === "like" ? ThumbsUp : ThumbsDown;
+
+	const toggleReason = (key) => {
+		setSelectedReasons((prev) => {
+			const copy = new Set(prev);
+			copy.has(key) ? copy.delete(key) : copy.add(key);
+			return copy;
+		});
+	};
+
+	const handleSubmit = () => {
+		onSubmit([...selectedReasons]);
+	};
+	const handleClose = () => {
+		setSelectedReasons(new Set());
+		onClose();
+	};
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-30 backdrop-blur-sm">
+			<div className="bg-white rounded-2xl p-6 w-full max-w-md shadow-lg">
+				<div className="flex justify-between items-center mb-4">
+					<div className="flex items-center space-x-2">
+						<Icon size={24} className={feedbackType === "like" ? "text-indigo-600" : "text-red-600"} />
+						<h3 className="text-lg font-semibold text-gray-900">{titleText}</h3>
+					</div>
+					<button onClick={handleClose} className="p-1 rounded hover:bg-gray-100">
+						<X size={20} className="text-gray-600" />
+					</button>
+				</div>
+				<p className="text-sm text-gray-600 italic mb-6 text-center">"{eventTitle}"</p>
+				<div className="grid grid-cols-2 gap-3 mb-6">
+					{options.map(({ key, label, description }) => (
+						<button key={key} onClick={() => toggleReason(key)} className={`py-2 px-3 rounded-lg text-sm text-left transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400 ${selectedReasons.has(key) ? "bg-indigo-100 border border-indigo-300" : "bg-white border border-gray-200 hover:bg-gray-50"}`}>
+							<div className="font-medium text-gray-800">{label}</div>
+							<div className="text-xs text-gray-600 mt-1">{description}</div>
+						</button>
+					))}
+				</div>
+				<div className="flex justify-end">
+					<button onClick={handleClose} className="mr-3 px-4 py-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-sm font-medium">
+						Cancel
+					</button>
+					<button onClick={handleSubmit} className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-sm font-medium text-white">
+						Submit
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/constants/options.js
+++ b/frontend/src/components/constants/options.js
@@ -1,0 +1,21 @@
+export const POSITIVE_OPTIONS = [
+	{ key: "fun", label: "Fun Environment", description: "The event had an enjoyable and lively atmosphere." },
+	{ key: "speaker", label: "Great Speaker", description: "The speaker was engaging, knowledgeable, and clear." },
+	{ key: "interactive", label: "Interactive", description: "Audience involvement via Q&A, polls, or activities made it engaging." },
+	{ key: "networking", label: "Networking Opportunities", description: "Met new people or professionals relevant to my goals." },
+	{ key: "career", label: "Career Relevant", description: "Content aligned with my career or academic interests." },
+	{ key: "organized", label: "Well Organized", description: "Schedule, communication, and execution were smooth." },
+	{ key: "timing", label: "Good Timing", description: "Fit well into my schedule; not too long or too short." },
+	{ key: "content", label: "Valuable Content", description: "Learned something new or walked away with useful insights." },
+];
+
+export const NEGATIVE_OPTIONS = [
+	{ key: "boring", label: "Boring Atmosphere", description: "The event lacked energy or felt dull." },
+	{ key: "poorSpeaker", label: "Poor Speaker", description: "Speaker was hard to follow, unprepared, or unengaging." },
+	{ key: "notInteractive", label: "Not Interactive", description: "No audience participation; felt like a lecture." },
+	{ key: "lowNetworking", label: "Low Networking Value", description: "Didn’t get a chance to connect with others." },
+	{ key: "offTopic", label: "Off-Topic", description: "Content wasn’t relevant to my interests or goals." },
+	{ key: "disorganized", label: "Disorganized", description: "Poor planning, delays, or technical issues." },
+	{ key: "badTiming", label: "Bad Timing", description: "Inconvenient time or too long/short to be worthwhile." },
+	{ key: "noTakeaways", label: "Lack of Takeaways", description: "Didn’t learn anything useful or actionable." },
+];


### PR DESCRIPTION
## Description  
- **What does this PR do?**  
  Adds a new `FeedbackModal` component styled like the existing event-creation modal. Moves positive/negative option lists into a shared `constants/options.js`. Integrates the modal into `Events.jsx` with icon buttons for like/dislike.  
- **Why is it necessary or valuable?**  
  Gives users a simple, consistent way to share why they liked or didn’t like an event. Keeps styling and code organized by reusing patterns and centralizing option data.  
- **What is intentionally left out and will be done later?**  
  - Persisting feedback to the database.  
  - Automated tests for UI interactions.  

---

## Milestones / Related Work  
- **Feature or user story: [4.1 Create UI for  like and dislike feedback modal for events (TC #2)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.zd2f5tdffj6z)

---

## Resources and References  
- **Icons:** `lucide-react` for ThumbsUp, ThumbsDown, X  

---

## Test Plan  
- Clicked thumbs up and thumbs down icons to open modal  
- Selected reasons, clicked Submit/Cancel, modal closes  
<img width="3454" height="1932" alt="image" src="https://github.com/user-attachments/assets/e52d1858-79e6-4caa-bcd9-1d25bcbc9bd0" />
<img width="3454" height="1908" alt="image" src="https://github.com/user-attachments/assets/e5596d62-46f1-487c-b4e4-da30168e00c0" />


### Edge Cases Tested  
- No reasons selected (Submit still closes modal)  
- Rapid open/close (state resets correctly)  
- Toggling reasons on/off  

---

## Additional Notes  
- Future PR: save feedback to Supabase and reccomendation logic and ui

