### PR TITLE
Add tab UI and feedback modal skeleton for events page (TC #2)

### DIFF
--- a/frontend/src/components/Events.jsx
+++ b/frontend/src/components/Events.jsx
@@ -47,14 +47,13 @@ export default function Events({ role }) {
 			setUserId(user.id);
 
 			const { data: regData } = await supabase.from("event_registrations").select("event_id").eq("user_id", user.id);
-			setRegistered(new Set(regData?.map((r) => r.event_id)));
+			setRegistered(new Set((regData || []).map((r) => r.event_id)));
 
 			const { data: userData } = await supabase.from("users").select("points").eq("id", user.id).single();
 			setPoints(userData?.points ?? 0);
 
 			const { data: eventData } = await supabase.from("events").select("id,title,description,location,date,points,users(name)").order("date", { ascending: true });
-
-			const initialEvents = eventData ?? [];
+			const initialEvents = eventData || [];
 			setEvents(initialEvents);
 			setLoading(false);
 
@@ -114,6 +113,76 @@ export default function Events({ role }) {
 		}
 	};
 
+	const renderList = (list) =>
+		list.map((e) => {
+			const isReg = registered.has(e.id);
+			return (
+				<div key={e.id} className="bg-white rounded-lg shadow-md p-6 flex flex-col">
+					<div className="flex justify-between items-start">
+						<h2 className="text-xl font-semibold">{e.title}</h2>
+						{role === "Admin" && (
+							<button onClick={() => deleteEvent(e.id)} className="text-red-600 hover:text-red-800 text-sm">
+								Delete
+							</button>
+						)}
+					</div>
+					<div className="text-sm text-gray-600 mt-1">+{e.points} pts</div>
+					<div className="text-gray-500 text-sm mt-1">
+						{new Date(e.date).toLocaleString(undefined, {
+							weekday: "short",
+							year: "numeric",
+							month: "short",
+							day: "numeric",
+							hour: "2-digit",
+							minute: "2-digit",
+							timeZoneName: "short",
+						})}
+					</div>
+					<div className="text-gray-500 text-sm">{e.location}</div>
+					<p className="mt-4 text-gray-700">{e.description}</p>
+					<div className="mt-4 text-sm text-gray-600">
+						Created by <span className="font-medium text-gray-800">{e.users?.name ?? "Unknown"}</span>
+					</div>
+					<div className="mt-6 flex items-center gap-4">
+						<button onClick={() => toggleRegister(e.id, e.points)} className={`text-sm font-medium py-2 px-4 rounded transition ${isReg ? "bg-gray-300 hover:bg-gray-400 text-black" : "bg-blue-500 hover:bg-blue-600 text-white"}`}>
+							{isReg ? "Cancel Registration" : "Register"}
+						</button>
+						<button
+							onClick={() => {
+								if (googleToken) addEventToGoogleCalendar(googleToken, e);
+								else loginWithGoogleCalendar();
+							}}
+							className="bg-red-500 hover:bg-red-600 text-white text-sm font-medium py-2 px-4 rounded transition"
+						>
+							{googleToken ? "Add to Google Calendar" : "Connect Google Calendar"}
+						</button>
+						<button
+							onClick={() => {
+								setModalEvent(e);
+								setFeedbackType("like");
+								setModalVisible(true);
+							}}
+							className="p-2 rounded hover:bg-gray-100"
+							aria-label="Like"
+						>
+							<ThumbsUp size={20} />
+						</button>
+						<button
+							onClick={() => {
+								setModalEvent(e);
+								setFeedbackType("dislike");
+								setModalVisible(true);
+							}}
+							className="p-2 rounded hover:bg-gray-100"
+							aria-label="Dislike"
+						>
+							<ThumbsDown size={20} />
+						</button>
+					</div>
+				</div>
+			);
+		});
+
 	if (loading) return <LoadingSpinner />;
 
 	return (
@@ -150,6 +219,7 @@ export default function Events({ role }) {
 						)}
 					</>
 				)}
+
 				<div className="mb-6 flex space-x-4">
 					<button onClick={() => setActiveTab("all")} className={`py-2 px-4 rounded ${activeTab === "all" ? "bg-indigo-600 text-white" : "bg-gray-100 text-gray-700"}`}>
 						All Events
@@ -159,87 +229,24 @@ export default function Events({ role }) {
 					</button>
 				</div>
 
-				<div className="space-y-6">
-					{events.map((e) => {
-						const isReg = registered.has(e.id);
-						return (
-							<div key={e.id} className="bg-white rounded-lg shadow-md p-6 flex flex-col">
-								<div className="flex justify-between items-start">
-									<h2 className="text-xl font-semibold">{e.title}</h2>
-									{role === "Admin" && (
-										<button onClick={() => deleteEvent(e.id)} className="text-red-600 hover:text-red-800 text-sm">
-											Delete
-										</button>
-									)}
-								</div>
-								<div className="text-sm text-gray-600 mt-1">+{e.points} pts</div>
-								<div className="text-gray-500 text-sm mt-1">
-									{new Date(e.date).toLocaleString(undefined, {
-										weekday: "short",
-										year: "numeric",
-										month: "short",
-										day: "numeric",
-										hour: "2-digit",
-										minute: "2-digit",
-										timeZoneName: "short",
-									})}
-								</div>
-								<div className="text-gray-500 text-sm">{e.location}</div>
-								<p className="mt-4 text-gray-700">{e.description}</p>
-								<div className="mt-4 text-sm text-gray-600">
-									Created by <span className="font-medium text-gray-800">{e.users?.name ?? "Unknown"}</span>
-								</div>
-								<div className="mt-6 flex items-center gap-4">
-									<button onClick={() => toggleRegister(e.id, e.points)} className={`text-sm font-medium py-2 px-4 rounded transition ${isReg ? "bg-gray-300 hover:bg-gray-400 text-black" : "bg-blue-500 hover:bg-blue-600 text-white"}`} title={isReg ? "Cancel Registration" : "Register"}>
-										{isReg ? "Cancel Registration" : "Register"}
-									</button>
-									<button
-										onClick={() => {
-											if (googleToken) addEventToGoogleCalendar(googleToken, e);
-											else loginWithGoogleCalendar();
-										}}
-										className="bg-red-500 hover:bg-red-600 text-white text-sm font-medium py-2 px-4 rounded transition"
-									>
-										{googleToken ? "Add to Google Calendar" : "Connect Google Calendar"}
-									</button>
-									<button
-										onClick={() => {
-											setModalEvent(e);
-											setFeedbackType("like");
-											setModalVisible(true);
-										}}
-										className="p-2 rounded hover:bg-gray-100"
-										aria-label="Like"
-									>
-										<ThumbsUp size={20} />
-									</button>
-									<button
-										onClick={() => {
-											setModalEvent(e);
-											setFeedbackType("dislike");
-											setModalVisible(true);
-										}}
-										className="p-2 rounded hover:bg-gray-100"
-										aria-label="Dislike"
-									>
-										<ThumbsDown size={20} />
-									</button>
-									<FeedbackModal
-										visible={modalVisible}
-										feedbackType={feedbackType}
-										eventTitle={modalEvent.title}
-										onSubmit={(reasons) => {
-											setModalVisible(false);
-										}}
-										onClose={() => setModalVisible(false)}
-									/>
-								</div>
-							</div>
-						);
-					})}
-					<div className="text-right mt-6 text-sm text-gray-600 font-semibold">Total Points: {points}</div>
-				</div>
+				<div className="space-y-6">{activeTab === "all" ? renderList(events) : recommendedEvents.length > 0 ? renderList(recommendedEvents) : <div className="text-center text-gray-500">No recommendations yet—give some feedback!</div>}</div>
+
+				<div className="text-right mt-6 text-sm text-gray-600 font-semibold">Total Points: {points}</div>
 			</div>
+
+			<FeedbackModal
+				visible={modalVisible}
+				feedbackType={feedbackType}
+				eventTitle={modalEvent.title}
+				onSubmit={async (reasons) => {
+					if (userId && modalEvent.id) {
+						await saveUserFeedback(userId, modalEvent.id, feedbackType === "like", reasons);
+						await refreshRecommendations(userId, events);
+					}
+					setModalVisible(false);
+				}}
+				onClose={() => setModalVisible(false)}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
# Description  
**- What does this PR do?**  
  Adds a UI tab system to switch between "All Events" and "Recommended" views. Also introduces the feedback modal's basic UI for liking and disliking events.  
**- Why is it necessary or valuable?**  
  Provides a cleaner experience for users to explore curated recommendations (coming soon) and begins scaffolding the feedback system for future interactivity.  
**- What is intentionally left out and will be done in a later PR?**  
Does not include the underlying logic for saving feedback or generating recommendations. That will be added in the next milestone.

---

# Milestones / Related Work  
**- Milestone or version target:** [4.2 Create UI for recommended events tab (TC #2)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.nn3mmy2203cd)

---

# Test Plan  
**- How was this tested?**  
  Manually tested tab switching and feedback modal display for both like and dislike triggers using mock data.
**- Screenshots or recordings:**  
<img width="964" height="682" alt="Screenshot 2025-07-14 at 11 00 24 PM" src="https://github.com/user-attachments/assets/dde5ab33-14cf-4088-bd5d-9cce252e347b" />
**- Seed or mock data used:**  
Used mock event data to test tabs

## Edge Cases Tested  
- "Recommended" tab shows placeholder if no recommendations  
- Google Calendar button works correctly in both tabs
---

# Additional Notes  
**- Known limitations:** Modal does not yet save feedback or re-calculate recommendations  
**- Planned follow-up PRs:** Integrate feedback submission and dynamic recommendation logic  
