### PR TITLE
Implement getEventFeedbackVectors to build frequency maps per event (TC#2)

### DIFF
--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -36,12 +36,21 @@ export async function getUserFeedbackMap() {
 	}
 }
 
+// build feedback count vectors for each event
 export function getEventFeedbackVectors(feedbackMap, eventIds) {
 	const vectorMap = {};
 	eventIds.forEach((id) => {
 		const eid = String(id);
 		const freq = {};
-		//Todo: add userfeedback loop
+		for (const uid in feedbackMap) {
+			const entry = feedbackMap[uid][eid];
+			if (entry) {
+				// count how many times each reason was given for this event
+				entry.reasons.forEach((r) => {
+					freq[r] = (freq[r] || 0) + 1;
+				});
+			}
+		}
 		vectorMap[eid] = freq;
 	});
 	return vectorMap;

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -38,5 +38,11 @@ export async function getUserFeedbackMap() {
 
 export function getEventFeedbackVectors(feedbackMap, eventIds) {
 	const vectorMap = {};
+	eventIds.forEach((id) => {
+		const eid = String(id);
+		const freq = {};
+		//Todo: add userfeedback loop
+		vectorMap[eid] = freq;
+	});
 	return vectorMap;
 }

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -26,7 +26,7 @@ export async function getUserFeedbackMap() {
 			const uid = user_id;
 			const eid = String(event_id);
 			if (!map[uid]) map[uid] = {};
-      // store liked status and convert reasons array to a set for fast lookup
+			// store liked status and convert reasons array to a set for fast lookup
 			map[uid][eid] = { liked, reasons: new Set(reasons) };
 		});
 		return map;
@@ -34,4 +34,9 @@ export async function getUserFeedbackMap() {
 		console.error("unexpected error in getUserFeedbackMap:", err);
 		return {};
 	}
+}
+
+export function getEventFeedbackVectors(feedbackMap, eventIds) {
+	const vectorMap = {};
+	return vectorMap;
 }


### PR DESCRIPTION
# Description  
- What does this PR do?  
  Implements `getEventFeedbackVectors`, a utility function that transforms user feedback into frequency vectors by counting how many users selected each reason for each event.

- Why is it necessary or valuable?  
  These frequency vectors are essential for applying clustering algorithms like K-Means to group events based on common feedback traits. It enables the system to understand shared characteristics across events.

- What is intentionally left out and will be done in a later PR?  
  - K-Means clustering logic  
  - Normalization or weighting of feedback frequencies  

---

# Milestones / Related Work  
- Feature or user story this contributes to: [4.3.5 Construct event feedback vectors for clustering (TC #2)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.mht8ef20tl8t)

---

# Test Plan  
- How was this tested?  
  Manually tested with mock feedback maps and sample event IDs

## Edge Cases Tested  
- Events with no feedback  
- Users without reasons array  

---

# Additional Notes  
- Known limitations: No normalization of frequencies yet; raw counts may overweight popular users  
- Planned follow-up PRs:  
  - Add vector normalization  
  - Integrate with clustering logic  
