### PR TITLE
 Add Euclidean distance utility and K-Means clustering function for event grouping (TC#2)

### DIFF
--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -73,8 +73,8 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 	let centroids = vectors.slice(0, kEff).map((v) => [...v.vec]);
 	let changed = true;
 	let clusters = {};
-  
-  while (changed) {
+
+	while (changed) {
 		clusters = {};
 		changed = false;
 
@@ -91,4 +91,15 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 			clusters[bestIdx] = clusters[bestIdx] || [];
 			clusters[bestIdx].push(id);
 		});
-  }
+		const newCentroids = centroids.map((_, i) => {
+			const members = (clusters[i] || []).map((id) => vectors.find((v) => v.id === id).vec);
+			if (!members.length) return centroids[i];
+			return features.map((_, j) => members.reduce((s, v) => s + v[j], 0) / members.length);
+		});
+
+		changed = centroids.some((c, i) => euclidean(c, newCentroids[i]) > 1e-3);
+		centroids = newCentroids;
+	}
+
+	return clusters;
+}

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -73,4 +73,22 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 	let centroids = vectors.slice(0, kEff).map((v) => [...v.vec]);
 	let changed = true;
 	let clusters = {};
-}
+  
+  while (changed) {
+		clusters = {};
+		changed = false;
+
+		vectors.forEach(({ id, vec }) => {
+			let bestIdx = 0;
+			let bestDist = Infinity;
+			centroids.forEach((c, i) => {
+				const d = euclidean(vec, c);
+				if (d < bestDist) {
+					bestDist = d;
+					bestIdx = i;
+				}
+			});
+			clusters[bestIdx] = clusters[bestIdx] || [];
+			clusters[bestIdx].push(id);
+		});
+  }

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -55,3 +55,9 @@ export function getEventFeedbackVectors(feedbackMap, eventIds) {
 	});
 	return vectorMap;
 }
+
+// calculate Euclidean distance between two vectors
+function euclidean(a, b) {
+	return Math.sqrt(a.reduce((sum, v, i) => sum + (v - b[i]) ** 2, 0));
+}
+

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -61,3 +61,16 @@ function euclidean(a, b) {
 	return Math.sqrt(a.reduce((sum, v, i) => sum + (v - b[i]) ** 2, 0));
 }
 
+export function clusterEventsKMeans(eventVectors, k = 5) {
+	const eids = Object.keys(eventVectors);
+	const features = Array.from(new Set(eids.flatMap((eid) => Object.keys(eventVectors[eid]))));
+	const vectors = eids.map((eid) => ({
+		id: eid,
+		vec: features.map((f) => eventVectors[eid][f] || 0),
+	}));
+
+	const kEff = Math.min(k, vectors.length);
+	let centroids = vectors.slice(0, kEff).map((v) => [...v.vec]);
+	let changed = true;
+	let clusters = {};
+}

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -61,9 +61,15 @@ function euclidean(a, b) {
 	return Math.sqrt(a.reduce((sum, v, i) => sum + (v - b[i]) ** 2, 0));
 }
 
+
+// cluster events into k groups using K-Means
 export function clusterEventsKMeans(eventVectors, k = 5) {
 	const eids = Object.keys(eventVectors);
+
+  // get all unique feedback types across events (ex. features)
 	const features = Array.from(new Set(eids.flatMap((eid) => Object.keys(eventVectors[eid]))));
+
+  // convert each event vector to a full vector using the global feature list
 	const vectors = eids.map((eid) => ({
 		id: eid,
 		vec: features.map((f) => eventVectors[eid][f] || 0),
@@ -78,6 +84,7 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 		clusters = {};
 		changed = false;
 
+    // assign each vector to the closest centroid
 		vectors.forEach(({ id, vec }) => {
 			let bestIdx = 0;
 			let bestDist = Infinity;
@@ -91,12 +98,14 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 			clusters[bestIdx] = clusters[bestIdx] || [];
 			clusters[bestIdx].push(id);
 		});
+    // recalculate centroids by averaging the vectors in each cluster
 		const newCentroids = centroids.map((_, i) => {
 			const members = (clusters[i] || []).map((id) => vectors.find((v) => v.id === id).vec);
 			if (!members.length) return centroids[i];
 			return features.map((_, j) => members.reduce((s, v) => s + v[j], 0) / members.length);
 		});
 
+    // check if centroids changed significantly
 		changed = centroids.some((c, i) => euclidean(c, newCentroids[i]) > 1e-3);
 		centroids = newCentroids;
 	}


### PR DESCRIPTION
### What is K-Means Clustering?

K-Means Clustering is an algorithm that groups similar data points together into **k** clusters. It works by picking **k center points (centroids)**, assigning each data point to the nearest one, and then adjusting the centers based on the average of each group. This repeats until the groups stop changing.

It's often used to find patterns or organize things based on similarity, like grouping events that got similar feedback from users.

# Description  
- What does this PR do?  
  Implements the `euclidean` distance utility and the `clusterEventsKMeans` function to group similar events based on user feedback vectors.

- Why is it necessary or valuable?  
  This enables clustering of events based on feedback patterns, which is foundational for surfacing personalized or related event suggestions to users. The distance utility is required for comparing event feature vectors.

- What is intentionally left out and will be done in a later PR?  
  - Integration of clustering output with the event recommendation system  
  - Dynamic selection or tuning of `k` clusters  

---

# Milestones / Related Work  
- Feature or user story this contributes to: - [4.4 Begin clustering events based on feedback traits using K-Means (TC #2)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.urrdufentgpw)

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
[Youtube Tutorial on K-means Clustering](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.urrdufentgpw)

- [Article about Calculating Euclidean Distance
](https://www.30secondsofcode.org/js/s/euclidean-distance/?utm_source=chatgpt.com)

---

# Test Plan  
- How was this tested?  
  Manually tested with sample `eventVectors` and various `k` values. Logged clusters and verified event groupings were logical.

- Seed or mock data used:  
  - Manually created event vectors with varying overlapping features  
  - Mocked different cluster scenarios to test behavior when `k > # of events` and `k = 1`

## Edge Cases Tested  
- `k` greater than number of events  
- Events with no overlapping features  

---

# Additional Notes  
- Known limitations:  
  - No vector normalization yet 
  - No persistence of cluster results

- Planned follow-up PRs:  
  - Normalize and weigh feature vectors  
