### PR TITLE
Create normalized user preference vector from liked feedback (TC #2)

### DIFF
--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -112,10 +112,12 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 	return clusters;
 }
 
+// build and normalize user preference vector from liked feedback
 export function getUserPreferenceVector(userId, feedbackMap) {
 	const freq = {};
 	const userFb = feedbackMap[userId] || {};
 
+	// build and normalize user preference vector from liked feedback
 	Object.keys(userFb).forEach((eid) => {
 		const { liked, reasons } = userFb[eid];
 		if (liked) {
@@ -125,6 +127,7 @@ export function getUserPreferenceVector(userId, feedbackMap) {
 		}
 	});
 
+	// normalize the counts into probabilities
 	const total = Object.values(freq).reduce((a, b) => a + b, 0) || 1;
 	const normalized = {};
 	Object.keys(freq).forEach((r) => {

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -124,4 +124,12 @@ export function getUserPreferenceVector(userId, feedbackMap) {
 			});
 		}
 	});
+
+	const total = Object.values(freq).reduce((a, b) => a + b, 0) || 1;
+	const normalized = {};
+	Object.keys(freq).forEach((r) => {
+		normalized[r] = freq[r] / total;
+	});
+
+	return normalized;
 }

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -61,15 +61,14 @@ function euclidean(a, b) {
 	return Math.sqrt(a.reduce((sum, v, i) => sum + (v - b[i]) ** 2, 0));
 }
 
-
 // cluster events into k groups using K-Means
 export function clusterEventsKMeans(eventVectors, k = 5) {
 	const eids = Object.keys(eventVectors);
 
-  // get all unique feedback types across events (ex. features)
+	// get all unique feedback types across events (ex. features)
 	const features = Array.from(new Set(eids.flatMap((eid) => Object.keys(eventVectors[eid]))));
 
-  // convert each event vector to a full vector using the global feature list
+	// convert each event vector to a full vector using the global feature list
 	const vectors = eids.map((eid) => ({
 		id: eid,
 		vec: features.map((f) => eventVectors[eid][f] || 0),
@@ -84,7 +83,7 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 		clusters = {};
 		changed = false;
 
-    // assign each vector to the closest centroid
+		// assign each vector to the closest centroid
 		vectors.forEach(({ id, vec }) => {
 			let bestIdx = 0;
 			let bestDist = Infinity;
@@ -98,17 +97,22 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 			clusters[bestIdx] = clusters[bestIdx] || [];
 			clusters[bestIdx].push(id);
 		});
-    // recalculate centroids by averaging the vectors in each cluster
+		// recalculate centroids by averaging the vectors in each cluster
 		const newCentroids = centroids.map((_, i) => {
 			const members = (clusters[i] || []).map((id) => vectors.find((v) => v.id === id).vec);
 			if (!members.length) return centroids[i];
 			return features.map((_, j) => members.reduce((s, v) => s + v[j], 0) / members.length);
 		});
 
-    // check if centroids changed significantly
+		// check if centroids changed significantly
 		changed = centroids.some((c, i) => euclidean(c, newCentroids[i]) > 1e-3);
 		centroids = newCentroids;
 	}
 
 	return clusters;
+}
+
+export function getUserPreferenceVector(userId, feedbackMap) {
+	const freq = {};
+	const userFb = feedbackMap[userId] || {};
 }

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -115,4 +115,13 @@ export function clusterEventsKMeans(eventVectors, k = 5) {
 export function getUserPreferenceVector(userId, feedbackMap) {
 	const freq = {};
 	const userFb = feedbackMap[userId] || {};
+
+	Object.keys(userFb).forEach((eid) => {
+		const { liked, reasons } = userFb[eid];
+		if (liked) {
+			reasons.forEach((r) => {
+				freq[r] = (freq[r] || 0) + 1;
+			});
+		}
+	});
 }


### PR DESCRIPTION
# Description  
- What does this PR do?  
  Adds the `getUserPreferenceVector` function to generate a normalized vector of feedback reasons based on a user's liked events.

- Why is it necessary or valuable?  
  This function allows us to understand each user's preferences by quantifying which feedback reasons they like most. It can be used for personalized recommendations, mentor matching, or event suggestions.

- What is intentionally left out and will be done in a later PR?  
  - RecommendEventsForUser function

---

# Milestones / Related Work  
- Feature or user story this contributes to:  [4.5 Build user preference vectors from liked feedback (TC #2)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.abf2wby53fe)

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
  - [Vector Based recommendation article
](https://www.e2enetworks.com/blog/how-to-create-a-vector-based-recommendation-system)
---

# Test Plan  
- How was this tested?  
  - Tested with mock feedbackMap inputs and verified the returned vector matched expected reason proportions.

- Seed or mock data used:  
  - Manually created `feedbackMap` with varied `liked` values and reasons

## Edge Cases Tested  
- User has no feedback  
- User has only disliked events  

---

# Additional Notes  
- Known limitations:  
  - Only liked feedback is used (dislikes are ignored for now)  
  - No filtering or weighting logic applied beyond frequency normalization

- Planned follow-up PRs:  
  - create RecommendEventsForUser function
