### PR TITLE
 Recommend top N events for a user based on preference and feedback clustering (TC #2)

### DIFF
--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -136,3 +136,9 @@ export function getUserPreferenceVector(userId, feedbackMap) {
 
 	return normalized;
 }
+
+export function recommendEventsForUser(userId, feedbackMap, clusterMap, eventVectors, topN = 5) {
+	const prefs = getUserPreferenceVector(userId, feedbackMap);
+	const seen = new Set(Object.keys(feedbackMap[userId] || {}));
+	const scored = [];
+}

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -158,4 +158,9 @@ export function recommendEventsForUser(userId, feedbackMap, clusterMap, eventVec
 			}
 		});
 	});
+	// return top N events sorted by relevance score
+	return scored
+		.sort((a, b) => b.score - a.score)
+		.slice(0, topN)
+		.map((o) => o.eid);
 }

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -137,8 +137,25 @@ export function getUserPreferenceVector(userId, feedbackMap) {
 	return normalized;
 }
 
+// recommend up to topN events based on user preferences
 export function recommendEventsForUser(userId, feedbackMap, clusterMap, eventVectors, topN = 5) {
 	const prefs = getUserPreferenceVector(userId, feedbackMap);
 	const seen = new Set(Object.keys(feedbackMap[userId] || {}));
 	const scored = [];
+	// iterate through each cluster's events
+	Object.values(clusterMap).forEach((members) => {
+		members.forEach((eid) => {
+			if (!seen.has(eid)) {
+				const vec = eventVectors[eid] || {};
+				let score = 0;
+
+				// compute dot product between user prefs and event vector
+				Object.keys(prefs).forEach((r) => {
+					score += prefs[r] * (vec[r] || 0);
+				});
+
+				if (score > 0) scored.push({ eid, score });
+			}
+		});
+	});
 }


### PR DESCRIPTION
# Description  
- What does this PR do?  
  Adds `recommendEventsForUser`, a function that scores and ranks events for a user based on the similarity between their normalized preference vector and event feedback vectors, returning the top N unseen events.

- Why is it necessary or valuable?  
  This enables personalized event recommendations using meaningful user feedback data. It improves the user experience by highlighting events that match individual interests and avoids repeating events the user already gave feedback on.

---

# Milestones / Related Work  
- Milestone or version target: [`4.6 Recommend events using preference vectors (TC #2)`  ](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.m47oqlgadk3z)

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
 [ Article on Vector Based Algs ](https://www.e2enetworks.com/blog/how-to-create-a-vector-based-recommendation-system  )

---

# Test Plan  
- How was this tested?  
  Tested manually real data from Supabase.

- Screenshots or recordings:  
[Loom Video Tutorial
](https://www.loom.com/share/3a57621f907446ce9f14c5f6d43c5d6f?sid=f028bbda-fbc3-4be2-a27e-bcad24170cd2)
## Edge Cases Tested  
- User has no feedback (empty preference vector)  
- Events have no overlap with user preferences  

---

# Additional Notes  
- Known limitations:  
  - Relies on dot product, which may favor long vectors

- Reviewer requests or feedback needed:  
  - Thoughts on switching from dot product to another alg?  
