### PR TITLE
Add LinkedIn Connect Button + Editable LinkedIn URL (Stretch)

### DIFF
--- a/frontend/src/components/EditProfile.jsx
+++ b/frontend/src/components/EditProfile.jsx
@@ -27,6 +27,7 @@ export default function EditPage() {
 	const [experienceYears, setExperienceYears] = useState("");
 	const [aiInterest, setAiInterest] = useState(false);
 	const [preferredMeeting, setPreferredMeeting] = useState("");
+	const [linkedInUrl, setLinkedInUrl] = useState("");
 
 	const PROFICIENCY_LEVELS = ["Beginner", "Intermediate", "Advanced"];
 	const yearOptions = ["Freshman", "Sophomore", "Junior", "Senior"];
@@ -75,7 +76,7 @@ export default function EditPage() {
 			const userId = session?.user?.id;
 			if (!userId) return;
 
-			const { data, error } = await supabase.from("users").select("profile_picture, name, year, bio, skills, interests, points, mentor_role, experience_years, ai_interest, preferred_meeting	").eq("id", userId).single();
+			const { data, error } = await supabase.from("users").select("profile_picture, name, year, bio, skills, interests, points, mentor_role, experience_years, ai_interest, preferred_meeting, linked_in_url").eq("id", userId).single();
 
 			if (error) {
 				console.error(error.message);
@@ -84,13 +85,14 @@ export default function EditPage() {
 				setName(data.name || "");
 				setYear(data.year || "");
 				setBio(data.bio || "");
-				setSkills(data.skills || []);
+				setSkills(data.skills || {});
 				setInterests(data.interests || []);
 				setProfilePreview(data.profile_picture || "");
 				setMentorRole(data.mentor_role || "");
 				setExperienceYears(data.experience_years || "");
 				setAiInterest(data.ai_interest ?? false);
 				setPreferredMeeting(data.preferred_meeting ?? "");
+				setLinkedInUrl(data.linked_in_url || "");
 			}
 			setLoading(false);
 		})();
@@ -118,9 +120,10 @@ export default function EditPage() {
 
 	const addCustomSkill = () => {
 		const v = skillInput.trim();
-		if (v && !skills.includes(v)) setSkills([...skills, v]);
+		if (v && !Object.keys(skills).includes(v)) setSkills({ ...skills, [v]: "Beginner" });
 		setSkillInput("");
 	};
+
 	const handleSkillKey = (e) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
@@ -131,14 +134,17 @@ export default function EditPage() {
 	const toggleInterest = (opt) => {
 		setInterests(interests.includes(opt) ? interests.filter((i) => i !== opt) : [...interests, opt]);
 	};
+
 	const removeInterest = (val) => {
 		setInterests(interests.filter((i) => i !== val));
 	};
+
 	const addCustomInterest = () => {
 		const v = interestInput.trim();
 		if (v && !interests.includes(v)) setInterests([...interests, v]);
 		setInterestInput("");
 	};
+
 	const handleInterestKey = (e) => {
 		if (e.key === "Enter") {
 			e.preventDefault();
@@ -180,6 +186,7 @@ export default function EditPage() {
 			experience_years: experienceYears,
 			ai_interest: aiInterest,
 			preferred_meeting: preferredMeeting,
+			linked_in_url: linkedInUrl,
 		};
 
 		const { error: saveErr } = await supabase.from("users").update(updates).eq("id", userId);
@@ -197,6 +204,7 @@ export default function EditPage() {
 			setProfilePreview(URL.createObjectURL(f));
 		}
 	};
+
 	const handleCancel = () => navigate("/profile");
 
 	if (loading) return <LoadingSpinner />;
@@ -223,12 +231,17 @@ export default function EditPage() {
 								</option>
 							))}
 						</select>
-						<p className="mt-4 text-sm font-medium text-blue-600">{userData.points ?? 0} points</p>
+						<p className="mt-4 text-sm font-medium text-blue-600">{userData?.points ?? 0} points</p>
 					</div>
 
 					<div className="bg-white p-6 rounded-xl shadow">
 						<h3 className="text-xl font-bold mb-2">About Me</h3>
 						<textarea rows={4} className="w-full bg-gray-100 p-2 rounded" placeholder="Tell us about yourself" value={bio} onChange={(e) => setBio(e.target.value)} />
+					</div>
+
+					<div className="bg-white p-6 rounded-xl shadow">
+						<h3 className="text-xl font-bold mb-2">LinkedIn URL</h3>
+						<input type="url" className="w-full bg-gray-100 p-2 rounded" placeholder="https://www.linkedin.com/in/your-profile" value={linkedInUrl} onChange={(e) => setLinkedInUrl(e.target.value)} />
 					</div>
 
 					<div className="bg-white p-6 rounded-xl shadow">
@@ -257,7 +270,6 @@ export default function EditPage() {
 								</button>
 							))}
 						</div>
-
 						<div className="flex gap-2">
 							<input className="flex-1 bg-gray-100 p-2 rounded" placeholder="Add a skill..." value={skillInput} onChange={(e) => setSkillInput(e.target.value)} onKeyDown={handleSkillKey} />
 							<button onClick={addCustomSkill} className="px-4 rounded bg-blue-600 text-white">

--- a/frontend/src/components/Members.jsx
+++ b/frontend/src/components/Members.jsx
@@ -61,6 +61,11 @@ export default function Members() {
 								</div>
 							</div>
 							<div className="mt-4 text-sm text-gray-600">{member.points ?? 0} points</div>
+							<div className="mt-4 flex justify-center w-full">
+								<a href={member.linked_in_url || "#"} target="_blank" rel="noopener noreferrer" className={`px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full text-sm shadow-sm ${member.linked_in_url ? "" : "opacity-50 pointer-events-none"}`}>
+									Connect
+								</a>
+							</div>
 						</div>
 					);
 				})}

--- a/frontend/src/components/MentorPage.jsx
+++ b/frontend/src/components/MentorPage.jsx
@@ -178,7 +178,9 @@ export default function MentorPage() {
 						</div>
 						<div className="text-sm text-gray-600 mb-2">{mentor.points ?? 0} total points</div>
 						<div className="flex gap-2">
-							<button className="px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full text-sm shadow-sm">Connect</button>
+							<a href={mentor.linked_in_url || "#"} target="_blank" rel="noopener noreferrer" className={`px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white rounded-full text-sm shadow-sm ${mentor.linked_in_url ? "" : "opacity-50 pointer-events-none"}`}>
+								Connect
+							</a>
 							<button onClick={() => toggleLike(mentor.id)} className={`px-4 py-2 rounded-full text-sm shadow-sm ${likedMentors.has(mentor.id) ? "bg-red-400 hover:bg-red-500 text-white" : "bg-yellow-400 hover:bg-yellow-500 text-white"}`}>
 								{likedMentors.has(mentor.id) ? "Unlike" : "Like"}
 							</button>


### PR DESCRIPTION
### Description
- **What does this PR do?**  
  1. Adds **Connect** buttons on **Members** and **MentorPage** that open each user’s LinkedIn profile in a new tab.  
  2. Enables editing of a new `linkedInUrl` field on **EditProfile** and persists it as `linked_in_url` in Supabase.  

- **Why is it valuable?**  
  Direct, one-click networking from within MICS Connect.

---

### Milestones / Related Work
- **Feature:** 4.9 [Users can edit their Linkedin URL in profile and connect W/ Mentor & Members Linkedin](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=kix.dfkyip5kdq71)


---

### Test Plan
1. **Manual test**  
   - Edit a profile, add a valid LinkedIn URL, save.  
   - Visit Members & Mentor pages → **Connect** opens LinkedIn in new tab.  
2. **Edge cases**  
   - Blank `linked_in_url` → button disabled (`opacity-50 pointer-events-none`).  

[Loom Video
](https://www.loom.com/share/0c640cfda5d543958c05be10257f8dbf)---

### Additional Notes
- **Known limitation:** No URL validation yet.  
