### PR TITLE
Mentor Matching Explanation & Tooltip (TC #1 Stretch)

### DIFF
--- a/frontend/src/components/MentorPage.jsx
+++ b/frontend/src/components/MentorPage.jsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from "react";
 import { supabase } from "../supabaseClient";
 import NavigationBar from "./NavigationBar";
 import LoadingSpinner from "./LoadingSpinner";
-import { getTopMentorMatches } from "../utils/mentorMatchUtils";
+import { getTopMentorMatches, generateMatchExplanation } from "../utils/mentorMatchUtils";
 import { UserAuth } from "../context/AuthContext";
 import { PRESET_SKILLS, PRESET_INTERESTS } from "./constants/presets";
 import Footer from "./Footer";
+import { HelpCircle } from "lucide-react";
 
 export default function MentorPage() {
 	const { session } = UserAuth();
@@ -113,7 +114,7 @@ export default function MentorPage() {
 					<h1 className="text-5xl font-black text-gray-900 tracking-tight relative z-10">Mentor Matching</h1>
 
 					<p className="text-gray-600 text-lg font-semibold max-w-2xl relative z-10">
-						Find mentors who match your <span className="text-indigo-600 font-semibold">skills</span> and <span className="text-indigo-600 font-semibold">interests</span>. Customize the weights below to get the most relevant recommendations.
+						Find mentors who match your <span className="text-indigo-600 font-semibold">skills</span>, <span className="text-indigo-600 font-semibold">interests</span>, <span className="text-indigo-600 font-semibold">meeting type</span>, <span className="text-indigo-600 font-semibold">ai interest</span>, and <span className="text-indigo-600 font-semibold">experience</span>. Customize the weights below to get the most relevant recommendations.
 					</p>
 
 					<button onClick={() => setShowWeightModal(true)} className="mt-2 px-6 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg shadow">
@@ -154,25 +155,31 @@ export default function MentorPage() {
 					</div>
 				)}
 
-				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 m-10">
+				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-8 py-6">
 					{topMentors.map(({ mentor, score }) => (
-						<div key={mentor.id} className="hover-pulse transition transform hover:scale-105 hover:ring-4 hover:ring-indigo-300 hover:ring-opacity-40 hover:ring-offset-2 bg-white shadow-lg rounded-xl p-6 flex flex-col items-center text-center border border-blue-200">
+						<div key={mentor.id} className="hover-pulse transition-transform transform hover:scale-105 hover:ring-4 hover:ring-indigo-300 hover:ring-opacity-40 hover:ring-offset-2 bg-white shadow-lg rounded-2xl p-6 flex flex-col items-center text-center border border-blue-200">
+							<div className="absolute top-3 right-3">
+								<HelpCircle className="peer w-5 h-5 text-gray-400 hover:text-gray-600 cursor-pointer" />
+								<div className="opacity-0 peer-hover:opacity-100 transition-opacity absolute right-0 mt-1 w-64 p-3 bg-white text-gray-800 text-sm rounded-lg shadow-lg z-20">{generateMatchExplanation(userProfile, mentor)}</div>
+							</div>
+
 							<div className="w-24 h-24 rounded-full overflow-hidden shadow-md border-4 border-blue-200 mb-4">
 								<img src={mentor.profile_picture || "https://picsum.photos/200"} alt={mentor.name} className="object-cover w-full h-full" />
 							</div>
 
-							<div className="text-lg font-bold flex items-center gap-2">
+							<div className="text-xl font-bold flex items-center gap-2 mb-2">
 								{mentor.name}
 								<span className="text-xs bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded-full">Mentor</span>
 							</div>
 
-							<div className="text-sm text-gray-600 mb-2">
-								{mentor.year || "N/A"} • {mentor.experience_years || 0} yrs experience
+							<div className="text-sm text-gray-600 mb-3">
+								{mentor.year || "N/A"} • {mentor.experience_years || 0} yr
+								{mentor.experience_years === 1 ? "" : "s"} experience
 							</div>
 
-							<p className="text-sm text-gray-700 mb-3">{mentor.bio || "No bio available."}</p>
+							<p className="text-sm text-gray-700 mb-4">{mentor.bio || "No bio available."}</p>
 
-							<div className="w-full mb-3">
+							<div className="w-full mb-4">
 								<div className="font-semibold text-sm mb-1">Skills</div>
 								<div className="flex flex-wrap gap-2 justify-center">
 									{mentor.skills &&

--- a/frontend/src/components/MentorPage.jsx
+++ b/frontend/src/components/MentorPage.jsx
@@ -111,10 +111,54 @@ export default function MentorPage() {
 			<div className="bg-gradient-to-b from-blue-100 via-blue-200 to-blue-300 text-gray-900 min-h-screen">
 				<NavigationBar />
 				<div className="flex flex-col items-center mt-12 space-y-4 text-center">
-					<h1 className="text-5xl font-black text-gray-900 tracking-tight relative z-10">Mentor Matching</h1>
+					<div className="flex items-center space-x-2">
+						<h1 className="text-5xl font-black text-gray-900 tracking-tight">Mentor Matching</h1>
+
+						<div className="relative inline-block">
+							<HelpCircle className="peer w-6 h-6 text-gray-400 hover:text-gray-600 cursor-pointer" />
+							<div
+								className="
+      pointer-events-none opacity-0 peer-hover:opacity-100 transition-opacity duration-200
+      absolute top-full left-1/2 transform -translate-x-1/2 mt-2
+      w-72 bg-white/95 backdrop-blur-sm border border-gray-200
+      text-gray-900 text-sm rounded-lg shadow-lg p-4 z-50
+    "
+							>
+								<div
+									className="
+        absolute -top-2 left-1/2 transform -translate-x-1/2
+        w-3 h-3 bg-white/95 border-l border-t border-gray-200 rotate-45
+      "
+								/>
+								<h3 className="font-semibold text-gray-900 mb-2">How matching works</h3>
+								<ul className="list-decimal list-inside space-y-2">
+									<li>
+										<span className="font-semibold text-indigo-600">Vectorize</span> you & mentors on&nbsp;
+										<span className="italic">skills</span>, <span className="italic">interests</span>,&nbsp;
+										<span className="italic">AI interest</span>, <span className="italic">experience</span>, and&nbsp;
+										<span className="italic">meeting type</span>.
+									</li>
+									<li>
+										<span className="font-semibold text-indigo-600">Compute</span> cosine similarity + your likes to build a weighted graph.
+									</li>
+									<li>
+										<span className="font-semibold text-indigo-600">Run</span> Personalized PageRank from you to rank mentors by proximity.
+									</li>
+									<li>
+										<span className="font-semibold text-indigo-600">Blend</span> 60% PageRank & 40% cosine for the final ranking.
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
 
 					<p className="text-gray-600 text-lg font-semibold max-w-2xl relative z-10">
-						Find mentors who match your <span className="text-indigo-600 font-semibold">skills</span>, <span className="text-indigo-600 font-semibold">interests</span>, <span className="text-indigo-600 font-semibold">meeting type</span>, <span className="text-indigo-600 font-semibold">ai interest</span>, and <span className="text-indigo-600 font-semibold">experience</span>. Customize the weights below to get the most relevant recommendations.
+						Find mentors who match your&nbsp;
+						<span className="text-indigo-600 font-semibold">skills</span>,&nbsp;
+						<span className="text-indigo-600 font-semibold">interests</span>,&nbsp;
+						<span className="text-indigo-600 font-semibold">meeting type</span>,&nbsp;
+						<span className="text-indigo-600 font-semibold">AI interest</span>, and&nbsp;
+						<span className="text-indigo-600 font-semibold">experience</span>. Customize the weights below to get the most relevant recommendations.
 					</p>
 
 					<button onClick={() => setShowWeightModal(true)} className="mt-2 px-6 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-lg shadow">
@@ -157,10 +201,13 @@ export default function MentorPage() {
 
 				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-8 py-6">
 					{topMentors.map(({ mentor, score }) => (
-						<div key={mentor.id} className="hover-pulse transition-transform transform hover:scale-105 hover:ring-4 hover:ring-indigo-300 hover:ring-opacity-40 hover:ring-offset-2 bg-white shadow-lg rounded-2xl p-6 flex flex-col items-center text-center border border-blue-200">
+						<div key={mentor.id} className="hover-pulse transition-transform transform hover:scale-105 hover:ring-4 hover:ring-indigo-300 hover:ring-opacity-40 hover:ring-offset-2 bg-white shadow-lg rounded-2xl p-6 flex flex-col items-center text-center border border-blue-200 relative">
 							<div className="absolute top-3 right-3">
 								<HelpCircle className="peer w-5 h-5 text-gray-400 hover:text-gray-600 cursor-pointer" />
-								<div className="opacity-0 peer-hover:opacity-100 transition-opacity absolute right-0 mt-1 w-64 p-3 bg-white text-gray-800 text-sm rounded-lg shadow-lg z-20">{generateMatchExplanation(userProfile, mentor)}</div>
+								<div className="opacity-0 peer-hover:opacity-100 transition-opacity  absolute right-0 mt-1 w-64 p-3 bg-white text-gray-800 text-sm rounded-lg shadow-lg z-20">
+									<div className="font-bold mb-2">Why did we match you?</div>
+									{generateMatchExplanation(userProfile, mentor)}
+								</div>
 							</div>
 
 							<div className="w-24 h-24 rounded-full overflow-hidden shadow-md border-4 border-blue-200 mb-4">

--- a/frontend/src/utils/feedbackUtils.js
+++ b/frontend/src/utils/feedbackUtils.js
@@ -2,7 +2,7 @@ import { supabase } from "../supabaseClient";
 import { academicBuildings } from "../components/constants/academicBuildings";
 export const FEEDBACK_TABLE = "event_feedback";
 
-//save/update user feedback for an event
+//save update user feedback for an event
 export async function saveUserFeedback(userId, eventId, liked, reasonsArray) {
 	try {
 		const { error } = await supabase.from(FEEDBACK_TABLE).upsert({ user_id: userId, event_id: eventId, liked, reasons: reasonsArray }, { onConflict: ["user_id", "event_id"] });

--- a/frontend/src/utils/mentorMatchUtils.js
+++ b/frontend/src/utils/mentorMatchUtils.js
@@ -1,3 +1,4 @@
+
 //Create a constant for the maximum years of experience to normalize against
 const MAX_YEARS = 5;
 

--- a/frontend/src/utils/mentorMatchUtils.js
+++ b/frontend/src/utils/mentorMatchUtils.js
@@ -1,3 +1,4 @@
+import React from "react";
 
 //Create a constant for the maximum years of experience to normalize against
 const MAX_YEARS = 5;
@@ -174,4 +175,70 @@ export function getTopMentorMatches(currentUser, mentors, globalSkills, globalIn
 
 	// 6. Sort, slice to topN, and return
 	return final.sort((a, b) => b.score - a.score).slice(0, topN);
+}
+// function for joining an array of strings into list
+function joinWithCommasAndAnd(items) {
+	if (items.length === 1) {
+		return items[0];
+	}
+	if (items.length === 2) {
+		return React.createElement(React.Fragment, null, items[0], " and ", items[1]);
+	}
+	// 3 items
+	const children = [];
+	items.forEach((item, idx) => {
+		children.push(item);
+		if (idx < items.length - 2) {
+			children.push(", ");
+		} else if (idx === items.length - 2) {
+			children.push(", and ");
+		}
+	});
+	return React.createElement(React.Fragment, null, ...children);
+}
+
+// Generates an explanation for why a user was matched with a mentor
+export function generateMatchExplanation(user, mentor) {
+	const reasons = [];
+
+	// shared skills - up to 2
+	if (user.skills && mentor.skills) {
+		const sharedSkills = Object.keys(user.skills)
+			.filter((s) => mentor.skills[s])
+			.slice(0, 2);
+		if (sharedSkills.length === 1) {
+			reasons.push(React.createElement(React.Fragment, { key: "skills-1" }, "you both know ", React.createElement("span", { className: "text-indigo-600 font-semibold" }, sharedSkills[0])));
+		} else if (sharedSkills.length === 2) {
+			reasons.push(React.createElement(React.Fragment, { key: "skills-2" }, "you both know ", React.createElement("span", { className: "text-indigo-600 font-semibold" }, sharedSkills[0]), " and ", React.createElement("span", { className: "text-indigo-600 font-semibold" }, sharedSkills[1])));
+		}
+	}
+
+	// shared interests - up to 2
+	if (user.interests && mentor.interests) {
+		const sharedInterests = user.interests.filter((i) => mentor.interests.includes(i)).slice(0, 2);
+		if (sharedInterests.length === 1) {
+			reasons.push(React.createElement(React.Fragment, { key: "interest-1" }, "you both are interested in ", React.createElement("span", { className: "text-purple-600 font-semibold" }, sharedInterests[0])));
+		} else if (sharedInterests.length === 2) {
+			reasons.push(React.createElement(React.Fragment, { key: "interest-2" }, "you both are interested in ", React.createElement("span", { className: "text-purple-600 font-semibold" }, sharedInterests[0]), " and ", React.createElement("span", { className: "text-purple-600 font-semibold" }, sharedInterests[1])));
+		}
+	}
+
+	// preffered meeting meeting
+	if (user.preferred_meeting && user.preferred_meeting === mentor.preferred_meeting) {
+		reasons.push(React.createElement(React.Fragment, { key: "meeting" }, "you both prefer ", React.createElement("span", { className: "text-teal-600 font-semibold" }, user.preferred_meeting.toLowerCase()), " sessions"));
+	}
+
+	// ai interest
+	if (user.ai_interest && mentor.ai_interest) {
+		reasons.push(React.createElement(React.Fragment, { key: "ai" }, "you’re both interested in ", React.createElement("span", { className: "text-pink-600 font-semibold" }, "AI")));
+	}
+
+	// fallback
+	if (reasons.length === 0) {
+		return React.createElement(React.Fragment, null, "We matched you based on ", React.createElement("span", { className: "font-semibold" }, "overall compatibility"), ".");
+	}
+
+	// build final sentence
+	const list = joinWithCommasAndAnd(reasons);
+	return React.createElement(React.Fragment, null, "We matched you because ", list, ".");
 }


### PR DESCRIPTION
## Description  
- **What does this PR do?**  
Implements a tooltip icon next to the **Mentor Matching** title and on each mentor card that, on hover, displays a detailed breakdown of how mentor–mentee matches are computed.

- **Why is it necessary or valuable?**  
Helps users understand *why* they see each mentor and helps them understand how the algorithms works.

---

## Milestones / Related Work  
- **Milestone or version target:**
[  - 4.14 Adding explanation for mentor matches explaining why you were matched (TC #1 Stretch) 
](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.3p1d2ayw0ina)  
[-4.14.5 Adding an explanation for how the mentor matching alg works (TC #1 Polish)
](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=id.3p1d2ayw0ina)

---

## Resources and References  
-[ **React.createElement** docs for JSX-free fragments  ](https://react.dev/reference/react/Fragment)

---

## Test Plan  
- **Manual testing:**  
  - Verified tooltip appears *only* when hovering the question-mark icon (both at the page header and on each card)  
  - Confirmed the tooltip content matches actual computation steps for various user/mentor pairs  
- **Screenshots**  
<img width="690" height="331" alt="image" src="https://github.com/user-attachments/assets/40887093-7357-415f-85f0-d800d296ed9c" />
<img width="562" height="215" alt="image" src="https://github.com/user-attachments/assets/36b0adff-a63f-4f57-95ba-20f9b4b5c283" />




### Edge Cases Tested  
- No shared attributes → fallback “overall compatibility” message  
- Single shared factor → singular sentence  
- Two+ shared factors → comma + “and” joined list  
- Different meeting preferences → no meeting-style reason  

---

## Additional Notes  
- **Reviewer feedback requested on:**  
  - Tooltip styling and readability  
  - Clarity of explanation language  
