### PR TITLE
Let user download .ics file if they don't have Outlook Calendar (MVP Stretch)

### DIFF
--- a/frontend/src/__tests__/Events.test.jsx
+++ b/frontend/src/__tests__/Events.test.jsx
@@ -381,4 +381,22 @@ describe("Events Component", () => {
 			});
 		});
 	});
+
+	describe("Calendar Integration", () => {
+		it("shows download button for ICS files", async () => {
+			renderEvents();
+			await waitFor(() => {
+				const downloadButtons = screen.getAllByText("Download");
+				expect(downloadButtons.length).toBeGreaterThan(0);
+			});
+		});
+
+		it("shows connect Google Calendar button when not connected", async () => {
+			renderEvents();
+			await waitFor(() => {
+				const googleButtons = screen.getAllByText("Connect Google Calendar");
+				expect(googleButtons.length).toBeGreaterThan(0);
+			});
+		});
+	});
 });


### PR DESCRIPTION
# Description  
- What does this PR do?  
  Adds support for users to download an `.ics` calendar file for any event, enabling calendar integration for users who do not use Outlook or Google Calendar.  
- Why is it necessary or valuable?  
  Some users may not use supported calendar integrations. This feature ensures broader accessibility by allowing any user to add events to their calendar using the industry-standard `.ics` format.  

---

# Milestones / Related Work  
- Milestone or version target: 
[  - 5.24 ICS file Implementation (Stretch MVP)](https://docs.google.com/document/d/1gKQkyru2JwfG13o2M-rWdAOgh8Qr6j2nxwepipoh564/edit?tab=t.0#bookmark=kix.7djx06dtmfw7)

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
  - https://icalendar.org/iCalendar-RFC-5545/3-6-1-event-component.html  


---

# Test Plan  
- How was this tested?  
  Manually verified `.ics` downloads across multiple events, checked file format opens in native calendar apps (Apple Calendar, Outlook, etc.).  
  Added unit test in `Events.test.jsx` to check for presence of download button.  
- Screenshots:  
<img width="517" height="264" alt="Hackathon Build for Social Good" src="https://github.com/user-attachments/assets/6ca33de0-fe48-491f-801b-5a6126297149" />


## Edge Cases Tested  
- Events with missing location  
- Events with no description  
- Events with special characters in title (cleaned for filename)

